### PR TITLE
fix crun logo size to match the others

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -43,7 +43,7 @@ Found a security issue? Most projects follow our [Security and Disclosure Policy
     <img src="https://github.com/containers/common/blob/main/logos/logo_circle_skopeo.png" alt="Skopeo" width="150px"/>
   </a>
   <a href="https://github.com/containers/crun">
-    <img src="https://github.com/containers/common/blob/main/logos/logo_circle_crun.png" alt="crun" width="135px"/>
+    <img src="https://github.com/containers/common/blob/main/logos/logo_circle_crun.png" alt="crun" width="150px"/>
   </a>
   <a href="https://github.com/containers/youki">
     <img src="https://github.com/containers/youki/blob/main/docs/youki_flat_full.png" alt="youki" width="150px"/>


### PR DESCRIPTION
All the other logos have a 150 px width, it looks weird that crun is a little bit smaller.